### PR TITLE
Fix namespacing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina-admin-conferences-accounts (0.1.0)
+    spina-admin-conferences-accounts (0.1.1)
       babel-transpiler (~> 0.7)
       devise (~> 4.8)
       rails (~> 6.1)

--- a/app/controllers/spina/admin/conferences/accounts/application_controller.rb
+++ b/app/controllers/spina/admin/conferences/accounts/application_controller.rb
@@ -6,6 +6,8 @@ module Spina
       module Accounts
         # Custom controller for accounts plugin. Sets the layout and adds a flash type.
         class ApplicationController < AdminController
+          helper ::Spina::Engine.routes.url_helpers
+
           add_flash_types :success
 
           layout :admin_layout, only: %i[new edit]

--- a/app/controllers/spina/admin/conferences/accounts/public_users_controller.rb
+++ b/app/controllers/spina/admin/conferences/accounts/public_users_controller.rb
@@ -36,8 +36,7 @@ module Spina
           private
 
           def public_user_params
-            params.require(:admin_conferences_accounts_public_user).permit(:email, :first_name, :last_name,
-                                                                           :institution)
+            params.require(:public_user).permit(:email, :first_name, :last_name, :institution)
           end
 
           def set_breadcrumb

--- a/app/views/spina/admin/conferences/accounts/public_users/_form.html.haml
+++ b/app/views/spina/admin/conferences/accounts/public_users/_form.html.haml
@@ -8,7 +8,7 @@
       = link_to '#', data: { close_notification: true } do
         = icon 'cross'
 
-= form_for @user, html: {autocomplete: "off"} do |f|
+= form_for [:admin_conferences_accounts, @user], html: {autocomplete: "off"} do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/lib/spina/admin/conferences/accounts/engine.rb
+++ b/lib/spina/admin/conferences/accounts/engine.rb
@@ -6,6 +6,8 @@ module Spina
       module Accounts
         # The plugin engine. Loads the plugin in Spina.
         class Engine < ::Rails::Engine
+          isolate_namespace Spina::Admin::Conferences::Accounts
+
           config.before_initialize do
             ::Spina::Plugin.register do |plugin|
               plugin.name = 'conferences-accounts'

--- a/lib/spina/admin/conferences/accounts/version.rb
+++ b/lib/spina/admin/conferences/accounts/version.rb
@@ -4,7 +4,7 @@ module Spina
   module Admin
     module Conferences
       module Accounts
-        VERSION = '0.1.0'
+        VERSION = '0.1.1'
       end
     end
   end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Spina
+  Account.first_or_create name: 'MyJournal', theme: 'default'
+  User.first_or_create name: 'Marcus Atherton', email: 'someone@someaddress.com', password: 'password', admin: true
+end


### PR DESCRIPTION
Correctly isolate `Spina::Admin::Conferences::Accounts` engine namespace and fix views. Also adds some basic seed data.